### PR TITLE
Add pmenu config

### DIFF
--- a/colors/acme.vim
+++ b/colors/acme.vim
@@ -15,6 +15,8 @@ highlight! Conceal guibg=bg guifg=fg gui=NONE ctermbg=bg ctermfg=fg cterm=NONE
 highlight! LineNr guibg=bg guifg=#505050 gui=italic ctermbg=bg ctermfg=239 cterm=italic
 highlight! Visual guibg=fg guifg=bg ctermbg=fg ctermfg=bg
 highlight! CursorLine guibg=#ffffca guifg=fg ctermbg=230 ctermfg=fg
+highlight! Pmenu guibg=bg guifg=fg ctermbg=bg ctermfg=fg
+highlight! PmenuSel guibg=fg guifg=bg ctermbg=fg ctermfg=bg
 
 highlight! Statement guibg=bg guifg=fg gui=italic ctermbg=bg ctermfg=fg cterm=italic
 highlight! Identifier guibg=bg guifg=fg gui=bold ctermbg=bg ctermfg=fg cterm=bold


### PR DESCRIPTION
Adds Pmenu config. As there's a highlight clear, if no highlight colors are configured for pmenus, they get pink.

Here I did some changes so the pmenu feels more at home in the colorscheme.

Thanks for the work on this colorscheme, I use it everyday :)

![Screenshot 2021-07-14 at 12 33 00](https://user-images.githubusercontent.com/14948182/125599652-7e4aa054-0bc9-45c7-86dd-2c79eaf5a4e2.png)
![Screenshot 2021-07-14 at 12 32 48](https://user-images.githubusercontent.com/14948182/125599657-2df1e7a8-f499-4ec2-8ac9-63803a7bd570.png)
